### PR TITLE
set the recommendation counter in the initial database

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -114,15 +114,18 @@ class Recommendation(db.Model):
         Recommendation(customer_id=2,
                        product_id=3,
                        recommend_product_id=4,
-                       recommend_type="upsell").save()
+                       recommend_type="upsell",
+                       rec_success=0).save()
         Recommendation(customer_id=5,
                        product_id=6,
                        recommend_product_id=7,
-                       recommend_type="downsell").save()
+                       recommend_type="downsell",
+                       rec_success=2).save()
         Recommendation(customer_id=5,
                        product_id=6,
                        recommend_product_id=8,
-                       recommend_type="upsell").save()
+                       recommend_type="upsell",
+                       rec_success=1).save()
 
     @classmethod
     def all(cls):


### PR DESCRIPTION
set the default value of the counter, or the value would be None and causes problems
```
vagrant@flask:/vagrant$ nosetests

Test Cases for Recommendations 
- Create a recommendation and add it to the database
- Create a recommendation and assert that it exists
- Delete a Recommendation
- Test deserialization of a Recommendation
- Test deserialization of bad data
- Test deserialization of a Recommendation with missing data
- Test deserialization of no data
- Find Recommendation by some attributes
- Find Recommendation by customer_id
- Find Recommendation by product_id
- Find Recommendation by recommend_type
- Find a Recommendation by ID
- Test serialization of a Recommendation
- Update a Recommendation

Recommendation Server Tests 
- Create a new Recommendation
- Create a new Recommendation with bad content type
- Delete a Recommendation
- Get a single Recommendation
- Get a list of Recommendations
- Get a Recommendation thats not found
- Test the Home Page
- Query by customer_id and product_id
- Query by an specific recommend_type return multiple entries
- Query by an non-exist recommend_type
- Increment Success
- Increment Success with bad id
- Update an existing Recommendation
- Update a Recommendation thats not found

Name                  Stmts   Miss  Cover
-----------------------------------------
service/__init__.py      18      0   100%
service/models.py        71      0   100%
service/service.py       85      0   100%
-----------------------------------------
TOTAL                   174      0   100%
----------------------------------------------------------------------
Ran 28 tests in 2.807s

OK

```